### PR TITLE
Rename daedalOS to CARLOS

### DIFF
--- a/components/apps/Browser/config.ts
+++ b/components/apps/Browser/config.ts
@@ -22,7 +22,7 @@ export const DINO_GAME = {
 export const bookmarks: Bookmark[] = [
   {
     icon: FAVICON_BASE_PATH,
-    name: "daedalOS",
+    name: "CARLOS",
     url: "https://dustinbrett.com/",
   },
   {

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -303,7 +303,7 @@ export const NEW_FILE_LABEL_TEXT = "New Text Document.txt";
 
 export const CLOCK_REGEX = /^(1[0-2]|0?[1-9])(?::[0-5]\d){2}\s?(AM|PM)$/;
 
-export const BASE_APP_TITLE = "daedalOS";
+export const BASE_APP_TITLE = "CARLOS";
 export const BASE_APP_FAVICON = /^\/favicon.ico$/;
 export const BASE_APP_FAVICON_TEXT = "/favicon.ico";
 

--- a/scripts/rssBuilder.js
+++ b/scripts/rssBuilder.js
@@ -57,7 +57,7 @@ const createRssFeedItems = (url) => {
   });
 };
 
-const name = "daedalOS";
+const name = "CARLOS";
 const rss = [
   '<?xml version="1.0" encoding="utf-8"?>',
   '<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -364,7 +364,7 @@ export const DEFAULT_SCROLLBAR_WIDTH = 17;
 export const TASKBAR_HEIGHT = 30;
 
 export const PACKAGE_DATA = {
-  alias: "daedalOS",
+  alias: "CARLOS",
   author: {
     email: "dustinbrett@gmail.com",
     name: "Dustin Brett",


### PR DESCRIPTION
This PR renames daedalOS to CARLOS in the codebase. The following files were updated:

1. utils/constants.ts - Updated PACKAGE_DATA.alias from "daedalOS" to "CARLOS"
2. e2e/constants.ts - Updated BASE_APP_TITLE from "daedalOS" to "CARLOS"
3. components/apps/Browser/config.ts - Updated name from "daedalOS" to "CARLOS"
4. scripts/rssBuilder.js - Updated name from "daedalOS" to "CARLOS"

This change is part of the project rebranding from daedalOS to CARLOS.